### PR TITLE
Global routing - Part. 1

### DIFF
--- a/src/app/private/player/player.js
+++ b/src/app/private/player/player.js
@@ -1,0 +1,30 @@
+angular.module('private.player', [
+    'private.player.sessions',
+    'private.player.sessions.join'
+])
+.config(function ($stateProvider) {
+    $stateProvider
+        .state('wegas.private.player', {
+            url: 'player',
+            views: {
+                'workspace': {
+                    controller: 'PlayerCtrl as playerCtrl',
+                    templateUrl: 'app/private/player/player.tmpl.html'
+                },
+                'sessions-join@wegas.private.player':{
+                    controller: 'SessionsNewCtrl as sessionsNewCtrl',
+                    templateUrl: 'app/private/player/sessions/sessions-join/sessions-join.tmpl.html'
+                },
+                'sessions-list@wegas.private.player':{
+                    controller: 'SessionsListCtrl as sessionsListCtrl',
+                    templateUrl: 'app/private/player/sessions/sessions.tmpl.html'
+                }
+            }
+        })
+    ;
+})
+.controller('PlayerCtrl', function PlayerCtrl($state) {
+    var playerCtrl = this;
+    console.log("Chargement player view");    
+});
+

--- a/src/app/private/player/player.tmpl.html
+++ b/src/app/private/player/player.tmpl.html
@@ -1,0 +1,3 @@
+<p>Private Player zone</p>
+<div ui-view="sessions-join"></div>
+<div ui-view="sessions-list"></div>

--- a/src/app/private/player/sessions/sessions-join/sessions-join.js
+++ b/src/app/private/player/sessions/sessions-join/sessions-join.js
@@ -1,0 +1,23 @@
+angular.module('private.player.sessions.join', [
+])
+.config(function ($stateProvider) {
+    $stateProvider
+        .state('wegas.private.player.sessions.join', {
+            url: '/join',
+            views: {
+                'sessions-new@wegas.private.player':{
+                    controller: 'SessionsJoinCtrl as sessionsJoinCtrl',
+                    templateUrl: 'app/private/player/sessions/sessions-join/sessions-join.tmpl.html'
+                },
+                'sessions-list@wegas.private.player': {
+                    controller: 'SessionsListCtrl as sessionsListCtrl',
+                    templateUrl: 'app/private/player/sessions/sessions.tmpl.html'
+                }
+            }
+        })
+    ;
+})
+.controller('SessionsJoinCtrl', function SessionsJoinCtrl($state) {
+    var sessionsJoinCtrl = this;
+    console.log("Chargement new session");    
+});

--- a/src/app/private/player/sessions/sessions-join/sessions-join.tmpl.html
+++ b/src/app/private/player/sessions/sessions-join/sessions-join.tmpl.html
@@ -1,0 +1,1 @@
+<p>New Session zone</p>

--- a/src/app/private/player/sessions/sessions-play/sessions-play.js
+++ b/src/app/private/player/sessions/sessions-play/sessions-play.js
@@ -1,0 +1,19 @@
+angular.module('private.player.sessions.play', [
+])
+.config(function ($stateProvider) {
+    $stateProvider
+        .state('wegas.private.player.sessions.play', {
+            url: '/:id/play',
+            views: {
+                'main@': {
+                    controller: 'SessionsPlayCtrl as sessionsPlayCtrl',
+                    templateUrl: 'app/private/player/sessions/sessions-play/sessions-play.tmpl.html'
+                }
+            }
+        })
+    ;
+})
+.controller('SessionsPlayCtrl', function SessionsPlayCtrl($state, $stateParams) {
+    var sessionsPlayCtrl = this;
+    console.log("Redirect to session No" + $stateParams.id);  
+});

--- a/src/app/private/player/sessions/sessions-play/sessions-play.tmpl.html
+++ b/src/app/private/player/sessions/sessions-play/sessions-play.tmpl.html
@@ -1,0 +1,1 @@
+<p>Redirect to played session</p>

--- a/src/app/private/player/sessions/sessions.js
+++ b/src/app/private/player/sessions/sessions.js
@@ -1,0 +1,26 @@
+angular.module('private.player.sessions', [
+    'private.player.sessions.join',
+    'private.player.sessions.play',
+    'private.player.sessions.team'
+])
+.config(function ($stateProvider) {
+    $stateProvider
+        .state('wegas.private.player.sessions', {
+            url: '/sessions',
+            views: {
+                'sessions-join':{
+                    controller: 'SessionsJoinCtrl as sessionsJoinCtrl',
+                    templateUrl: 'app/private/player/sessions/sessions-join/sessions-join.tmpl.html'
+                },
+                'sessions-list': {
+                    controller: 'SessionsListCtrl as sessionsListCtrl',
+                    templateUrl: 'app/private/player/sessions/sessions.tmpl.html'
+                }
+            }
+        })
+    ;
+})
+.controller('SessionsListCtrl', function SessionsListCtrl($state) {
+    var sessionsListCtrl = this;
+    console.log("Chargement player sessions list");    
+});

--- a/src/app/private/player/sessions/sessions.tmpl.html
+++ b/src/app/private/player/sessions/sessions.tmpl.html
@@ -1,0 +1,2 @@
+<p>Sessions list</p>
+<p><em>End of Nested Route</em></p>

--- a/src/app/private/player/sessions/team/team.js
+++ b/src/app/private/player/sessions/team/team.js
@@ -1,0 +1,19 @@
+angular.module('private.player.sessions.team', [
+])
+.config(function ($stateProvider) {
+    $stateProvider
+        .state('wegas.private.player.sessions.team', {
+            url: '/:id/team',
+            views: {
+                'workspace@wegas.private':{
+                    controller: 'SessionsTeamCtrl as sessionsTeamCtrl',
+                    templateUrl: 'app/private/player/sessions/team/team.tmpl.html'
+                }
+            }
+        })
+    ;
+})
+.controller('SessionsTeamCtrl', function SessionsTeamCtrl($state, $stateParams) {
+    var sessionsTeamCtrl = this;
+    console.log("Chargement des users de la session No " + $stateParams.id);    
+});

--- a/src/app/private/player/sessions/team/team.tmpl.html
+++ b/src/app/private/player/sessions/team/team.tmpl.html
@@ -1,0 +1,2 @@
+<p>Sessions team zone</p>
+<p><em>End of Nested Route</em></p>

--- a/src/app/private/private.js
+++ b/src/app/private/private.js
@@ -1,0 +1,23 @@
+angular.module('private', [
+   'private.player',
+   'private.trainer',
+   'private.scenarist'
+])
+.config(function ($stateProvider) {
+    $stateProvider
+        .state('wegas.private', {
+            url: '',
+            abstract:true,
+            views: {
+                'main@': {
+                    controller: 'PrivateCtrl as privateCtrl',
+                    templateUrl: 'app/private/private.tmpl.html'
+                }
+            }
+        })
+    ;
+})
+.controller('PrivateCtrl', function PrivateCtrl($state) {
+    var privateCtrl = this;
+    console.log("Chargement private view");    
+});

--- a/src/app/private/private.tmpl.html
+++ b/src/app/private/private.tmpl.html
@@ -1,0 +1,2 @@
+<p>Private Menu here</p>
+<div ui-view="workspace"></div>

--- a/src/app/private/scenarist/scenarios/scenarios-download/scenarios-download.js
+++ b/src/app/private/scenarist/scenarios/scenarios-download/scenarios-download.js
@@ -1,0 +1,19 @@
+angular.module('private.scenarist.scenarios.download', [
+])
+.config(function ($stateProvider) {
+    $stateProvider
+        .state('wegas.private.scenarist.scenarios.download', {
+            url: '/:id/download',
+            views: {
+                'workspace@wegas.private': {
+                    controller: 'ScenariosDownloadCtrl as scenariosDownloadCtrl',
+                    templateUrl: 'app/private/scenarist/scenarios/scenarios-download/scenarios-download.tmpl.html'
+                }
+            }
+        })
+    ;
+})
+.controller('ScenariosDownloadCtrl', function ScenariosDownloadCtrl($state, $stateParams) {
+    var scenariosDownloadCtrl = this;
+    console.log("Download scenarios No" + $stateParams.id);  
+});

--- a/src/app/private/scenarist/scenarios/scenarios-download/scenarios-download.tmpl.html
+++ b/src/app/private/scenarist/scenarios/scenarios-download/scenarios-download.tmpl.html
@@ -1,0 +1,1 @@
+<p>Download scenarios versions</p>

--- a/src/app/private/scenarist/scenarios/scenarios-edit/scenarios-edit.js
+++ b/src/app/private/scenarist/scenarios/scenarios-edit/scenarios-edit.js
@@ -1,0 +1,19 @@
+angular.module('private.scenarist.scenarios.edit', [
+])
+.config(function ($stateProvider) {
+    $stateProvider
+        .state('wegas.private.scenarist.scenarios.edit', {
+            url: '/:id/edit',
+            views: {
+                'main@': {
+                    controller: 'ScenariosEditCtrl as scenariosEditCtrl',
+                    templateUrl: 'app/private/scenarist/scenarios/scenarios-edit/scenarios-edit.tmpl.html'
+                }
+            }
+        })
+    ;
+})
+.controller('ScenariosEditCtrl', function ScenariosEditCtrl($state, $stateParams) {
+    var scenariosEditCtrl = this;
+    console.log("Redirect to scenario No" + $stateParams.id);  
+});

--- a/src/app/private/scenarist/scenarios/scenarios-edit/scenarios-edit.tmpl.html
+++ b/src/app/private/scenarist/scenarios/scenarios-edit/scenarios-edit.tmpl.html
@@ -1,0 +1,1 @@
+<p>Redirect to scenario to edit</p>

--- a/src/app/private/scenarist/scenarios/scenarios-new/scenarios-new.js
+++ b/src/app/private/scenarist/scenarios/scenarios-new/scenarios-new.js
@@ -1,0 +1,23 @@
+angular.module('private.scenarist.scenarios.new', [
+])
+.config(function ($stateProvider) {
+    $stateProvider
+        .state('wegas.private.scenarist.scenarios.new', {
+            url: '/new',
+            views: {
+                'scenarios-new@wegas.private.scenarist':{
+                    controller: 'ScenariosNewCtrl as scenariosNewCtrl',
+                    templateUrl: 'app/private/scenarist/scenarios/scenarios-new/scenarios-new.tmpl.html'
+                },
+                'scenarios-list@wegas.private.scenarist': {
+                    controller: 'ScenariosListCtrl as scenariosListCtrl',
+                    templateUrl: 'app/private/scenarist/scenarios/scenarios.tmpl.html'
+                }
+            }
+        })
+    ;
+})
+.controller('ScenariosNewCtrl', function ScenariosNewCtrl($state) {
+    var scenariosNewCtrl = this;
+    console.log("Chargement new scenario");    
+});

--- a/src/app/private/scenarist/scenarios/scenarios-new/scenarios-new.tmpl.html
+++ b/src/app/private/scenarist/scenarios/scenarios-new/scenarios-new.tmpl.html
@@ -1,0 +1,1 @@
+<p>New Scenario zone</p>

--- a/src/app/private/scenarist/scenarios/scenarios.js
+++ b/src/app/private/scenarist/scenarios/scenarios.js
@@ -1,0 +1,27 @@
+angular.module('private.scenarist.scenarios', [
+    'private.scenarist.scenarios.new',
+    'private.scenarist.scenarios.edit',
+    'private.scenarist.scenarios.users',
+    'private.scenarist.scenarios.download'
+])
+.config(function ($stateProvider) {
+    $stateProvider
+        .state('wegas.private.scenarist.scenarios', {
+            url: '/scenarios',
+            views: {
+                'scenarios-new':{
+                    controller: 'ScenariosNewCtrl as scenariosNewCtrl',
+                    templateUrl: 'app/private/scenarist/scenarios/scenarios-new/scenarios-new.tmpl.html'
+                },
+                'scenarios-list': {
+                    controller: 'ScenariosListCtrl as scenariosListCtrl',
+                    templateUrl: 'app/private/scenarist/scenarios/scenarios.tmpl.html'
+                }
+            }
+        })
+    ;
+})
+.controller('ScenariosListCtrl', function ScenariosListCtrl($state) {
+    var scenariosListCtrl = this;
+    console.log("Chargement scenarist scenarios list");    
+});

--- a/src/app/private/scenarist/scenarios/scenarios.tmpl.html
+++ b/src/app/private/scenarist/scenarios/scenarios.tmpl.html
@@ -1,0 +1,2 @@
+<p>Scenarios list</p>
+<p><em>End of Nested Route</em></p>

--- a/src/app/private/scenarist/scenarios/users/users.js
+++ b/src/app/private/scenarist/scenarios/users/users.js
@@ -1,0 +1,19 @@
+angular.module('private.scenarist.scenarios.users', [
+])
+.config(function ($stateProvider) {
+    $stateProvider
+        .state('wegas.private.scenarist.scenarios.users', {
+            url: '/:id/users',
+            views: {
+                'workspace@wegas.private':{
+                    controller: 'ScenariosUsersCtrl as scenariosUsersCtrl',
+                    templateUrl: 'app/private/scenarist/scenarios/users/users.tmpl.html'
+                }
+            }
+        })
+    ;
+})
+.controller('ScenariosUsersCtrl', function ScenariosUsersCtrl($state, $stateParams) {
+    var scenariosUsersCtrl = this;
+    console.log("Chargement des users du scenarios No " + $stateParams.id);    
+});

--- a/src/app/private/scenarist/scenarios/users/users.tmpl.html
+++ b/src/app/private/scenarist/scenarios/users/users.tmpl.html
@@ -1,0 +1,2 @@
+<p>Scenario's users zone</p>
+<p><em>End of Nested Route</em></p>

--- a/src/app/private/scenarist/scenarist.js
+++ b/src/app/private/scenarist/scenarist.js
@@ -1,0 +1,29 @@
+angular.module('private.scenarist', [
+    'private.scenarist.scenarios',
+    'private.scenarist.scenarios.new'
+])
+.config(function ($stateProvider) {
+    $stateProvider
+        .state('wegas.private.scenarist', {
+            url: 'scenarist',
+            views: {
+                'workspace': {
+                    controller: 'ScenaristCtrl as scenaristCtrl',
+                    templateUrl: 'app/private/scenarist/scenarist.tmpl.html'
+                },
+                'scenarios-new@wegas.private.scenarist':{
+                    controller: 'ScenariosNewCtrl as scenariosNewCtrl',
+                    templateUrl: 'app/private/scenarist/scenarios/scenarios-new/scenarios-new.tmpl.html'
+                },
+                'scenarios-list@wegas.private.scenarist':{
+                    controller: 'ScenariosListCtrl as scenariosListCtrl',
+                    templateUrl: 'app/private/scenarist/scenarios/scenarios.tmpl.html'
+                }
+            }
+        })
+    ;
+})
+.controller('ScenaristCtrl', function ScenaristCtrl($state) {
+    var scenaristCtrl = this;
+    console.log("Chargement scenarist view");    
+});

--- a/src/app/private/scenarist/scenarist.tmpl.html
+++ b/src/app/private/scenarist/scenarist.tmpl.html
@@ -1,0 +1,3 @@
+<p>Private Scenarist zone</p>
+<div ui-view="scenarios-new"></div>
+<div ui-view="scenarios-list"></div>

--- a/src/app/private/trainer/sessions/sessions-manage/sessions-manage.js
+++ b/src/app/private/trainer/sessions/sessions-manage/sessions-manage.js
@@ -1,0 +1,20 @@
+angular.module('private.trainer.sessions.manage', [
+])
+.config(function ($stateProvider) {
+    $stateProvider
+        .state('wegas.private.trainer.sessions.manage', {
+            url: '/:id/manage',
+            views: {
+                'main@': {
+                    controller: 'SessionsManageCtrl as sessionsManageCtrl',
+                    templateUrl: 'app/private/trainer/sessions/sessions-manage/sessions-manage.tmpl.html'
+                }
+            }
+        })
+    ;
+})
+.controller('SessionsManageCtrl', function SessionsManageCtrl($state, $stateParams) {
+    var sessionsManageCtrl = this;
+    console.log("Redirect to session No" + $stateParams.id);  
+    console.log()  
+});

--- a/src/app/private/trainer/sessions/sessions-manage/sessions-manage.tmpl.html
+++ b/src/app/private/trainer/sessions/sessions-manage/sessions-manage.tmpl.html
@@ -1,0 +1,1 @@
+<p>Redirect to managed session</p>

--- a/src/app/private/trainer/sessions/sessions-new/sessions-new.js
+++ b/src/app/private/trainer/sessions/sessions-new/sessions-new.js
@@ -1,0 +1,23 @@
+angular.module('private.trainer.sessions.new', [
+])
+.config(function ($stateProvider) {
+    $stateProvider
+        .state('wegas.private.trainer.sessions.new', {
+            url: '/new',
+            views: {
+                'sessions-new@wegas.private.trainer':{
+                    controller: 'SessionsNewCtrl as sessionsNewCtrl',
+                    templateUrl: 'app/private/trainer/sessions/sessions-new/sessions-new.tmpl.html'
+                },
+                'sessions-list@wegas.private.trainer': {
+                    controller: 'SessionsListCtrl as sessionsListCtrl',
+                    templateUrl: 'app/private/trainer/sessions/sessions.tmpl.html'
+                }
+            }
+        })
+    ;
+})
+.controller('SessionsNewCtrl', function SessionsNewCtrl($state) {
+    var sessionsNewCtrl = this;
+    console.log("Chargement new session");    
+});

--- a/src/app/private/trainer/sessions/sessions-new/sessions-new.tmpl.html
+++ b/src/app/private/trainer/sessions/sessions-new/sessions-new.tmpl.html
@@ -1,0 +1,1 @@
+<p>New Session zone</p>

--- a/src/app/private/trainer/sessions/sessions.js
+++ b/src/app/private/trainer/sessions/sessions.js
@@ -1,0 +1,26 @@
+angular.module('private.trainer.sessions', [
+    'private.trainer.sessions.new',
+    'private.trainer.sessions.manage',
+    'private.trainer.sessions.users'
+])
+.config(function ($stateProvider) {
+    $stateProvider
+        .state('wegas.private.trainer.sessions', {
+            url: '/sessions',
+            views: {
+                'sessions-new':{
+                    controller: 'SessionsNewCtrl as sessionsNewCtrl',
+                    templateUrl: 'app/private/trainer/sessions/sessions-new/sessions-new.tmpl.html'
+                },
+                'sessions-list': {
+                    controller: 'SessionsListCtrl as sessionsListCtrl',
+                    templateUrl: 'app/private/trainer/sessions/sessions.tmpl.html'
+                }
+            }
+        })
+    ;
+})
+.controller('SessionsListCtrl', function SessionsListCtrl($state) {
+    var sessionsListCtrl = this;
+    console.log("Chargement trainer sessions list");    
+});

--- a/src/app/private/trainer/sessions/sessions.tmpl.html
+++ b/src/app/private/trainer/sessions/sessions.tmpl.html
@@ -1,0 +1,2 @@
+<p>Sessions list</p>
+<p><em>End of Nested Route</em></p>

--- a/src/app/private/trainer/sessions/users/users.js
+++ b/src/app/private/trainer/sessions/users/users.js
@@ -1,0 +1,19 @@
+angular.module('private.trainer.sessions.users', [
+])
+.config(function ($stateProvider) {
+    $stateProvider
+        .state('wegas.private.trainer.sessions.users', {
+            url: '/:id/users',
+            views: {
+                'workspace@wegas.private':{
+                    controller: 'SessionsUsersCtrl as sessionsUsersCtrl',
+                    templateUrl: 'app/private/trainer/sessions/users/users.tmpl.html'
+                }
+            }
+        })
+    ;
+})
+.controller('SessionsUsersCtrl', function SessionsUsersCtrl($state, $stateParams) {
+    var sessionsUsersCtrl = this;
+    console.log("Chargement des users de la session No " + $stateParams.id);    
+});

--- a/src/app/private/trainer/sessions/users/users.tmpl.html
+++ b/src/app/private/trainer/sessions/users/users.tmpl.html
@@ -1,0 +1,2 @@
+<p>Sessions users zone</p>
+<p><em>End of Nested Route</em></p>

--- a/src/app/private/trainer/trainer.js
+++ b/src/app/private/trainer/trainer.js
@@ -1,0 +1,29 @@
+angular.module('private.trainer', [
+    'private.trainer.sessions',
+    'private.trainer.sessions.new'
+])
+.config(function ($stateProvider) {
+    $stateProvider
+        .state('wegas.private.trainer', {
+            url: 'trainer',
+            views: {
+                'workspace': {
+                    controller: 'TrainerCtrl as trainerCtrl',
+                    templateUrl: 'app/private/trainer/trainer.tmpl.html'
+                },
+                'sessions-new@wegas.private.trainer':{
+                    controller: 'SessionsNewCtrl as sessionsNewCtrl',
+                    templateUrl: 'app/private/trainer/sessions/sessions-new/sessions-new.tmpl.html'
+                },
+                'sessions-list@wegas.private.trainer':{
+                    controller: 'SessionsListCtrl as sessionsListCtrl',
+                    templateUrl: 'app/private/trainer/sessions/sessions.tmpl.html'
+                }
+            }
+        })
+    ;
+})
+.controller('TrainerCtrl', function TrainerCtrl($state) {
+    var trainerCtrl = this;
+    console.log("Chargement trainer view");    
+});

--- a/src/app/private/trainer/trainer.tmpl.html
+++ b/src/app/private/trainer/trainer.tmpl.html
@@ -1,0 +1,3 @@
+<p>Private Trainer zone</p>
+<div ui-view="sessions-new"></div>
+<div ui-view="sessions-list"></div>

--- a/src/app/public/public-login/public-login.js
+++ b/src/app/public/public-login/public-login.js
@@ -1,0 +1,19 @@
+angular.module('public.login', [
+])
+.config(function ($stateProvider) {
+    $stateProvider
+        .state('wegas.public.login', {
+            url: '/login',
+        	views: {
+        		"form" :{
+            		controller: 'PublicLoginCtrl as publicLoginCtrl',
+            		templateUrl: 'app/public/public-login/public-login.tmpl.html'
+            	}
+            }
+        })
+    ;
+})
+.controller('PublicLoginCtrl', function PublicLoginCtrl() {
+    var publicLoginCtrl = this;
+    console.log("Chargement public login");    
+});

--- a/src/app/public/public-login/public-login.tmpl.html
+++ b/src/app/public/public-login/public-login.tmpl.html
@@ -1,0 +1,2 @@
+<p>public area for login</p>
+<p><em>End of Nested Route</em></p>

--- a/src/app/public/public-password/public-password.js
+++ b/src/app/public/public-password/public-password.js
@@ -1,0 +1,20 @@
+angular.module('public.password', [
+])
+.config(function ($stateProvider) {
+    $stateProvider
+        .state('wegas.public.password', {
+            url: '/password',
+            views: {
+        		"form" :{
+            		controller: 'PublicPasswordCtrl as publicPasswordCtrl',
+            		templateUrl: 'app/public/public-password/public-password.tmpl.html'
+            	}
+            }
+            
+        })
+    ;
+})
+.controller('PublicPasswordCtrl', function PublicPasswordCtrl() {
+    var publicPasswordCtrl = this;
+    console.log("Chargement public password");    
+});

--- a/src/app/public/public-password/public-password.tmpl.html
+++ b/src/app/public/public-password/public-password.tmpl.html
@@ -1,0 +1,2 @@
+<p>public area for remember password</p>
+<p><em>End of Nested Route</em></p>

--- a/src/app/public/public-signup/public-signup.js
+++ b/src/app/public/public-signup/public-signup.js
@@ -1,0 +1,20 @@
+angular.module('public.signup', [
+])
+.config(function ($stateProvider) {
+    $stateProvider
+        .state('wegas.public.signup', {
+            url: '/signup',
+            views: {
+                "form@": {
+                 	controller: 'PublicSignupCtrl as publicSignupCtrl',
+            		templateUrl: 'app/public/public-signup/public-signup.tmpl.html'
+                }
+            }
+           
+        })
+    ;
+})
+.controller('PublicSignupCtrl', function PublicSignupCtrl() {
+    var publicSignupCtrl = this;
+    console.log("Chargement public signup");    
+});

--- a/src/app/public/public-signup/public-signup.js
+++ b/src/app/public/public-signup/public-signup.js
@@ -5,7 +5,7 @@ angular.module('public.signup', [
         .state('wegas.public.signup', {
             url: '/signup',
             views: {
-                "form@": {
+                "form": {
                  	controller: 'PublicSignupCtrl as publicSignupCtrl',
             		templateUrl: 'app/public/public-signup/public-signup.tmpl.html'
                 }

--- a/src/app/public/public-signup/public-signup.tmpl.html
+++ b/src/app/public/public-signup/public-signup.tmpl.html
@@ -1,0 +1,2 @@
+<p>public area for signup</p>
+<p><em>End of Nested Route</em></p>

--- a/src/app/public/public.js
+++ b/src/app/public/public.js
@@ -1,0 +1,26 @@
+angular.module('public', [
+    'public.login',
+    'public.signup',
+    'public.password'
+])
+.config(function ($stateProvider) {
+    $stateProvider
+        .state('wegas.public', {
+            url: 'public',
+            views: {
+                'main@': {
+                    controller: 'PublicIndexCtrl as publicIndexCtrl',
+                    templateUrl: 'app/public/public.tmpl.html'
+                },
+                "form@wegas.public": {
+                    controller: 'PublicLoginCtrl as publicLoginCtrl',
+                    templateUrl: 'app/public/public-login/public-login.tmpl.html'
+                }
+            }
+        })
+    ;
+})
+.controller('PublicIndexCtrl', function PublicIndexCtrl($state) {
+    var publicIndexCtrl = this;
+    console.log("Chargement public index");    
+});

--- a/src/app/public/public.tmpl.html
+++ b/src/app/public/public.tmpl.html
@@ -1,0 +1,2 @@
+<p>public area</p>
+<div ui-view="form"></div>

--- a/src/app/wegas.js
+++ b/src/app/wegas.js
@@ -11,7 +11,7 @@ angular.module('Wegas', [
             views: {
                 'main@': {
                     controller: 'WegasMainCtrl as wegasMailCtrl',
-                    templateUrl: 'app/app.tmpl.html'
+                    templateUrl: 'app/wegas.tmpl.html'
                 }
             }
         })

--- a/src/app/wegas.js
+++ b/src/app/wegas.js
@@ -1,16 +1,24 @@
-'use strict';
 var ServiceURL =  "/api/"
 angular.module('Wegas', [
     'ui.router',
-    'users'
+    'public',
+    'private'
 ])
 .config(function ($stateProvider, $urlRouterProvider) {
     $stateProvider
         .state('wegas', {
-            url: '',
-            abstract: true
+            url: '/',
+            views: {
+                'main@': {
+                    controller: 'WegasMainCtrl as wegasMailCtrl',
+                    templateUrl: 'app/app.tmpl.html'
+                }
+            }
         })
     ;
     $urlRouterProvider.otherwise('/');
-})
-;
+}).controller('WegasMainCtrl', function WegasMainCtrl($state) {
+    var wegasMailCtrl = this;
+    console.log("Chargement main ctrl");    
+    $state.go("wegas.public");
+});

--- a/src/app/wegas.tmpl.html
+++ b/src/app/wegas.tmpl.html
@@ -1,0 +1,1 @@
+<p>Chargement de Wegas</p>


### PR DESCRIPTION
Première partie de la construction de l'app avec une première itération sur la création des routes pour l'ensemble de l'app. 

Le routing ne commence plus avec un seul élément Users mais 3 points d'entrées : 
- / qui va vérifier l'utilisateur courant et le rediriger vers une vue publique ou privée
- Les routes publiques qui vérifie si un utilisateur est connecté, si oui le user est redirigé vers les vues privées.  
- Les routes privées qui vérifie si un utilisateur est connecté, le redirige vers une vue publique sinon. 

Toutes les routes sont enfants de ces 2 dernières, donc on peut flanquer la sécurité dans le contrôleurs des  états "private" et "public", les enfants hériteront de la sécurité. C'est mieux non?  

Si ça semble OK, la partie 2 c'est l'intégration du travail fait sur le routing 1 sur le nouveau routing afin de supprimer l'ancien routing, et l'intégration du service "Auth" basé sur le service "Users" existant. 
