### PR TITLE
Fix bug overflow menu

### DIFF
--- a/src/assets/sass/objects/_view.scss
+++ b/src/assets/sass/objects/_view.scss
@@ -16,6 +16,7 @@
         width:100%;
         height:54px;
         z-index:4;
+        overflow:visible;
     }
 
     &.view--workspace{
@@ -286,6 +287,7 @@
         width:50%;
         height:100%;
         float:left;
+        overflow:visible;
     }
     .view__headding-workspace{
         margin:0px;


### PR DESCRIPTION
La classe view est à overflow-y:auto, ce qui gène l'affichage du menu.
Ici, surcharge le style de la vue menu pour pouvoir laisser view tel quel. 
